### PR TITLE
Widen desktop layout, rewrite README, update creators list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,25 @@
-# 🌌 Milky-Way
-Milky Way brings forth a minimalist design ethos, allowing your work to shine like stars in the night sky. With clean lines and intuitive navigation, visitors are guided effortlessly through your portfolio, focusing solely on your creations.
+# willo.dev
 
-Embrace the whimsical charm of Milky Way as it showcases your talents in a manner that's both elegant and endearing. Whether you're a designer, developer, artist, or creative professional of any kind, Milky Way provides the perfect canvas to showcase your endeavors.
+Personal site and blog for Will Osbourne — [willo.dev](https://willo.dev).
 
-With its responsive design, Milky Way ensures a seamless experience across devices, from desktops to smartphones, so your portfolio is accessible to all who wish to explore it. Let your work take center stage against the backdrop of this celestial template.
+## Architecture
 
-<p align="center">
-  <img align="center" alt="Astro" src="https://storage.googleapis.com/dev-portal-bucket/qh7sxskkyty67x3fznww5mwv4pxq59dk2aax51.webp"/>
-</p>
+Static site built with [Astro 4](https://astro.build) and deployed to Netlify. Content lives in two places:
 
-[![Built with Astro](https://astro.badg.es/v2/built-with-astro/tiny.svg)](https://astro.build) [![Netlify Status](https://api.netlify.com/api/v1/badges/0b0bcb79-a1d8-4b32-9566-8f30af19e4cc/deploy-status)](https://app.netlify.com/sites/astro-milky-way/deploys)
+- **Local content collections** (`src/content/`) — Markdown projects and posts, defined in `src/content/config.ts`.
+- **Ghost** — long-form blog posts are pulled from a headless Ghost instance at build time via the Content API (`src/lib/ghost.ts`).
 
-## 🔥 Features
-- [x] Simple and clean design, perfect for showcasing your work.
-- [x] Responsive layout for seamless viewing across different devices.
-- [x] Fast and efficient, thanks to the Astro static site generator.
-- [x] Easy to customize with CSS and straightforward HTML structure.
+The unified feed (`/feed/`) blends articles, thoughts, and links, with individual entries rendered at `/feed/[slug]/`. An RSS feed is generated at `/rss.xml`. Privacy-friendly analytics are provided by [Umami](https://umami.is).
 
-## ⚓ Lighthouse Score
-<p align="center">
-  <img width="600" alt="Lighthouse Score" src="https://raw.githubusercontent.com/ttomczak3/Milky-Way/6e386e2f920c993c33d348a9c1271a1cec6c6d2b/milkyway-lighthouse-score.svg"/>
-</p>
+Styling is a single global stylesheet (`src/styles/global.css`). Dark mode is the default; a `.light` class on `<html>` (toggled by the theme switcher and persisted in `localStorage`) activates the light theme.
 
-## 🚀 Getting Started
-Clone this repository to your local machine using Git.
-
-```scheme
-git clone https://github.com/ttomczak3/Milky-Way.git
-cd Milky-Way
-```
+## Development
 
 | Command           | Action                                       |
 | :---------------- | :------------------------------------------- |
-| `npm install`     | Installs dependencies                        |
-| `npm run dev`     | Starts local dev server at `localhost:4321`  |
-| `npm run build`   | Build your production site to `./dist/`      |
-| `npm run preview` | Preview your build locally, before deploying |
+| `npm install`     | Install dependencies                         |
+| `npm run dev`     | Start the dev server at `localhost:4321`     |
+| `npm run build`   | Type-check with `astro check`, then build to `./dist/` |
+| `npm run preview` | Preview the production build locally         |
 
-Edit the HTML files in the `src/pages` directory to add your projects, experiences, and personal information. You can also modify the CSS styles in `src/styles` to match your preferences.
-
-## 📂 Project Structure
-
-```
-/
-├── public/
-│   └── GitHub.webp
-│   └── blog-post.webp
-│   └── blog.webp
-│   └── favicon.svg
-│   └── laptop.webp
-│   └── space.webp
-│   └── youtube.webp
-├── src/
-│   ├── components/
-│   ├── content/
-│   ├── layouts/
-│   ├── pages/
-│   ├── styles/
-│   └── env.d.ts
-└── package.json
-```
-
-## 💻 Contributing
-Contributions to this project are welcome. If you find a bug or have a suggestion for improvement, please open an issue or submit a pull request.
-
-## 📃 License
-This project is licensed under the MIT License. See the `LICENSE` file for details.
-
-## ☕ Support
-If you enjoy Milky-Way and would like to show your support and appreciation through a tip, I would gratefully accept it.
-
-[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/X8X0P7FGR)
+See `.env.example` for the required environment variables (Ghost API and Umami config).

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,7 +18,7 @@ const pageTitle = "Will Osbourne";
     </p>
     <p>
         To stay sharp with new technology, frameworks, and methodologies, Will likes to follow innovative, thoughtful
-        creators, like Wes Bos and Scott Tolinski of Syntax, Dann Berg, DHH, and tante. Not frequently on social media,
+        creators, like Wes Bos and Scott Tolinski of Syntax, Dann Berg, Evan Hahn, and tante. Not frequently on social media,
         his curated RSS feeds and podcast queues are his lifeline to the greater trends of technology.
     </p>
     <div class="center">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -18,8 +18,11 @@ html {
 }
 
 body {
-  max-width: 540px;
+  max-width: 720px;
+  width: 100%;
   margin: 0 auto;
+  padding: 0 1.5rem;
+  box-sizing: border-box;
   text-align: justify;
 }
 
@@ -472,6 +475,8 @@ li {
 .pro-img {
   border-radius: 16px;
   margin-top: 10px;
+  max-width: 100%;
+  height: auto;
 }
 
 /* Footer */
@@ -623,10 +628,6 @@ html.light {
 
 /* Media Query */
 @media only screen and (max-width: 600px) {
-  body {
-    width: 350px;
-  }
-
   .navbar {
     display: initial;
   }
@@ -656,6 +657,6 @@ html.light {
 
   .pro-img {
     height: auto;
-    width: 350px;
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary

Small set of changes to the site:

- **Wider desktop layout.** Bumped `body` `max-width` from `540px` to `720px` and made it fluid (`width: 100%` + `1.5rem` horizontal padding, `box-sizing: border-box`). Desktop no longer feels squished while staying readable on mobile.
- **More responsive images/mobile.** `.pro-img` is now `max-width: 100%` and the mobile media query uses fluid `100%` widths instead of a fixed `350px`, so content flows naturally on any small screen rather than a hardcoded width.
- **New README.** Replaced the leftover Milky-Way template README with a short description of the site and its architecture (Astro 4 + Netlify, local content collections + headless Ghost, unified `/feed/`, Umami analytics, dark/light theming).
- **Creators list.** Removed DHH and added Evan Hahn on the homepage.

## Testing

- `astro check` passes (0 errors/warnings) and the client/static build compiles.
- The full `astro build` requires production Ghost credentials (`GHOST_URL`) to render `/feed/` routes, which aren't available locally — this is pre-existing and unrelated to these changes.