### PR TITLE
Redesign feed as a typed timeline (desktop + mobile)

### DIFF
--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -7,26 +7,33 @@ interface Props {
 }
 
 const { post } = Astro.props;
-const hasImage = !!post.feature_image;
 const excerpt = post.custom_excerpt || post.excerpt || "";
+const date = formatDate(post.published_at);
 ---
 
 <li class="feed-item feed-item--article">
-  <a class="feed-item__link" href={`/feed/${post.slug}/`}>
-    <div class="article-card__body">
-      <h3 class="feed-item__title">{post.title}</h3>
-      {excerpt && <p class="article-card__excerpt">{excerpt}</p>}
-      <time class="feed-item__date" datetime={post.published_at}>
-        {formatDate(post.published_at)}
+  <time class="feed-item__date feed-item__date--gutter" datetime={post.published_at}>
+    {date}
+  </time>
+  <div class="feed-item__spine" aria-hidden="true">
+    <span class="feed-item__line"></span>
+    <span class="feed-item__node feed-item__node--article">
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+        <line x1="3" y1="4.5" x2="13" y2="4.5"></line>
+        <line x1="3" y1="8" x2="13" y2="8"></line>
+        <line x1="3" y1="11.5" x2="9" y2="11.5"></line>
+      </svg>
+    </span>
+  </div>
+  <a class="feed-item__content feed-item__link" href={`/feed/${post.slug}/`}>
+    <h3 class="feed-item__title">{post.title}</h3>
+    {excerpt && <p class="feed-item__body">{excerpt}</p>}
+    <div class="feed-item__meta">
+      <time class="feed-item__date feed-item__date--inline" datetime={post.published_at}>
+        {date}
       </time>
+      <span class="feed-item__sep" aria-hidden="true">&middot;</span>
+      <span class="feed-item__action">Read article &rarr;</span>
     </div>
-    {hasImage && (
-      <img
-        class="article-card__thumb"
-        src={post.feature_image}
-        alt={post.feature_image_alt || post.title}
-        loading="lazy"
-      />
-    )}
   </a>
 </li>

--- a/src/components/LinkCard.astro
+++ b/src/components/LinkCard.astro
@@ -8,31 +8,52 @@ interface Props {
 
 const { post } = Astro.props;
 const domain = post.externalUrl ? getSourceDomain(post.externalUrl) : null;
+const date = formatDate(post.published_at);
 ---
 
 <li class="feed-item feed-item--link">
-  <div class="link-card__header">
-    <a
-      class="link-card__title"
-      href={post.externalUrl!}
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label={`${post.title} (opens ${domain} in a new tab)`}
-    >
-      {post.title}
-      <span class="link-card__arrow" aria-hidden="true">&nearr;</span>
-    </a>
-    {domain && <span class="link-card__domain">{domain}</span>}
+  <time class="feed-item__date feed-item__date--gutter" datetime={post.published_at}>
+    {date}
+  </time>
+  <div class="feed-item__spine" aria-hidden="true">
+    <span class="feed-item__line"></span>
+    <span class="feed-item__node feed-item__node--link">
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="4.5" y1="11.5" x2="11.5" y2="4.5"></line>
+        <polyline points="5.5,4.5 11.5,4.5 11.5,10.5"></polyline>
+      </svg>
+    </span>
   </div>
-  {post.html && (
-    <div class="link-card__commentary" set:html={post.html} />
-  )}
-  <div class="link-card__meta">
-    <time class="feed-item__date" datetime={post.published_at}>
-      {formatDate(post.published_at)}
-    </time>
-    <a class="link-card__permalink" href={`/feed/${post.slug}/`}>
-      &infin;
-    </a>
+  <div class="feed-item__content">
+    {domain && (
+      <a
+        class="link-card__domain"
+        href={post.externalUrl!}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`${post.title} (opens ${domain} in a new tab)`}
+      >
+        {domain} &nearr;
+      </a>
+    )}
+    <h3 class="feed-item__title feed-item__title--link">
+      <a
+        class="link-card__title"
+        href={post.externalUrl!}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {post.title}
+      </a>
+    </h3>
+    {post.html && <div class="link-card__commentary" set:html={post.html} />}
+    <div class="feed-item__meta">
+      <time class="feed-item__date feed-item__date--inline" datetime={post.published_at}>
+        {date}
+      </time>
+      <a class="link-card__permalink" href={`/feed/${post.slug}/`} aria-label="Permalink">
+        &infin;
+      </a>
+    </div>
   </div>
 </li>

--- a/src/components/ThoughtBlock.astro
+++ b/src/components/ThoughtBlock.astro
@@ -7,11 +7,23 @@ interface Props {
 }
 
 const { post } = Astro.props;
+const date = formatDate(post.published_at);
 ---
 
 <li class="feed-item feed-item--thought" id={`thought-${post.id}`}>
-  <div class="thought__content" set:html={post.html} />
-  <time class="feed-item__date" datetime={post.published_at}>
-    {formatDate(post.published_at)}
+  <time class="feed-item__date feed-item__date--gutter" datetime={post.published_at}>
+    {date}
   </time>
+  <div class="feed-item__spine" aria-hidden="true">
+    <span class="feed-item__line"></span>
+    <span class="feed-item__node feed-item__node--thought"></span>
+  </div>
+  <div class="feed-item__content">
+    <div class="thought__content" set:html={post.html} />
+    <div class="feed-item__meta">
+      <time class="feed-item__date feed-item__date--inline" datetime={post.published_at}>
+        {date}
+      </time>
+    </div>
+  </div>
 </li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,6 +10,11 @@
   --underline: #375a7f;
   --header: "Pacifico", cursive;
   --body: "Josefin Sans", sans-serif;
+  /* Feed timeline type accents */
+  --feed-article: #6f83a6; /* muted blue (--underline family, lifted for dark bg) */
+  --feed-link: #78c2ad; /* --text-link teal */
+  --feed-thought: #b7935f; /* warm accent, harmonizes with light theme */
+  --feed-line: rgba(253, 235, 243, 0.14);
 }
 
 html {
@@ -196,117 +201,190 @@ li {
   padding: 0;
 }
 
-/* Feed */
+/* Feed — timeline layout (design 2a desktop / 2b mobile) */
 .feed {
   list-style: none;
   padding: 0;
+  margin: 1.5rem 0 0;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 0;
 }
 
 .feed-item {
-  padding: 0;
+  display: flex;
+  align-items: stretch;
 }
 
+/* Date gutter (desktop) */
 .feed-item__date {
-  display: block;
   font-family: var(--body);
   font-size: 0.85rem;
   opacity: 0.6;
-  margin-top: 0.4rem;
 }
 
-/* Article Card */
-.feed-item--article .feed-item__link {
+.feed-item__date--gutter {
+  flex: 0 0 78px;
+  text-align: right;
+  padding: 0.15rem 1rem 0 0;
+}
+
+.feed-item__date--inline {
+  display: none;
+}
+
+/* Spine + node */
+.feed-item__spine {
+  flex: 0 0 26px;
+  position: relative;
   display: flex;
-  align-items: flex-start;
-  gap: 1rem;
+  justify-content: center;
+}
+
+.feed-item__line {
+  width: 2px;
+  height: 100%;
+  background: var(--feed-line);
+}
+
+.feed-item__node {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--background);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.feed-item__node--article::before,
+.feed-item__node--link::before {
+  content: "";
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+}
+
+.feed-item__node--article {
+  color: var(--feed-article);
+}
+
+.feed-item__node--article::before {
+  background: color-mix(in srgb, var(--feed-article) 18%, transparent);
+}
+
+.feed-item__node--link {
+  color: var(--feed-link);
+}
+
+.feed-item__node--link::before {
+  background: color-mix(in srgb, var(--feed-link) 20%, transparent);
+}
+
+.feed-item__node--article svg,
+.feed-item__node--link svg {
+  position: relative;
+}
+
+.feed-item__node--thought {
+  width: 9px;
+  height: 9px;
+  background: var(--feed-thought);
+  margin-top: 7px;
+}
+
+/* Content column */
+.feed-item__content {
+  flex: 1;
+  min-width: 0;
+  padding: 0 0 2.1rem 1.1rem;
+}
+
+.feed-item__title {
+  font-family: var(--body);
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.25;
+  margin: 0 0 0.35rem;
+  text-align: left;
+}
+
+.feed-item__body {
+  font-family: var(--body);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  opacity: 0.75;
+  margin: 0 0 0.5rem;
+  text-indent: 0;
+  text-align: left;
+}
+
+.feed-item__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--body);
+  font-size: 0.8rem;
+  opacity: 0.6;
+}
+
+.feed-item__action {
+  display: inline;
+}
+
+.feed-item__sep {
+  display: none;
+}
+
+/* Article */
+.feed-item__link {
+  display: block;
   text-decoration: none;
   color: var(--text);
   border-radius: 8px;
 }
 
-.feed-item--article .feed-item__link:hover .feed-item__title {
+.feed-item__link:hover .feed-item__title {
   text-decoration: underline;
-  text-decoration-color: var(--underline);
+  text-decoration-color: var(--feed-article);
   text-underline-offset: 3px;
   text-decoration-thickness: 2px;
 }
 
-.article-card__body {
-  flex: 1;
-  min-width: 0;
+.feed-item--article .feed-item__meta {
+  gap: 0.4rem;
 }
 
-.article-card__excerpt {
-  font-family: var(--body);
-  font-size: 0.9rem;
-  line-height: 1.4;
-  opacity: 0.7;
-  margin: 0.2rem 0 0;
-  text-indent: 0;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.article-card__thumb {
-  width: 72px;
-  height: 72px;
-  object-fit: cover;
-  border-radius: 8px;
-  flex-shrink: 0;
-}
-
-.feed-item__title {
-  font-family: var(--body);
-  font-size: 1.1rem;
-  font-weight: 600;
-  margin: 0;
-  text-align: left;
-}
-
-/* Thought Block */
-.feed-item--thought {
-  border-left: 3px solid var(--button);
-  padding-left: 1rem;
-}
-
+/* Thought */
 .thought__content {
   font-family: var(--body);
   font-size: 1.05rem;
-  line-height: 1.5;
+  line-height: 1.6;
 }
 
 .thought__content p {
   text-indent: 0;
+  text-align: left;
   margin: 0 0 0.5rem;
 }
 
 .thought__content p:last-child {
-  margin-bottom: 0;
+  margin-bottom: 0.5rem;
 }
 
-/* Link Card */
-.feed-item--link {
-  border-left: 3px solid var(--text-link);
-  padding-left: 1rem;
-}
-
-.link-card__header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 0.5rem;
+/* Link */
+.feed-item--link .feed-item__title {
+  font-size: 1.1rem;
+  margin-bottom: 0.4rem;
 }
 
 .link-card__title {
-  font-family: var(--body);
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: var(--text-link);
+  color: var(--feed-link);
   text-decoration: none;
 }
 
@@ -314,33 +392,43 @@ li {
   text-decoration: underline;
 }
 
-.link-card__arrow {
-  font-size: 0.9em;
-  margin-left: 0.15em;
+.link-card__domain {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: var(--body);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--feed-link);
+  background: color-mix(in srgb, var(--feed-link) 15%, transparent);
+  padding: 0.25em 0.6em;
+  border-radius: 6px;
+  text-decoration: none;
+  margin-bottom: 0.5rem;
 }
 
-.link-card__domain {
-  font-family: var(--body);
-  font-size: 0.8rem;
-  opacity: 0.5;
+.link-card__domain:hover {
+  background: color-mix(in srgb, var(--feed-link) 25%, transparent);
+  text-decoration: none;
 }
 
 .link-card__commentary {
   font-family: var(--body);
-  font-size: 1rem;
-  line-height: 1.5;
-  margin-top: 0.3rem;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  opacity: 0.85;
 }
 
 .link-card__commentary p {
   text-indent: 0;
-  margin: 0.3rem 0;
+  text-align: left;
+  margin: 0 0 0.5rem;
 }
 
-.link-card__meta {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
+.link-card__commentary p:last-child {
+  margin-bottom: 0.5rem;
 }
 
 .link-card__permalink {
@@ -556,6 +644,14 @@ footer {
 html.light {
   background-color: var(--background-light);
   color: var(--text-light);
+  --feed-article: #375a7f; /* --underline */
+  --feed-link: #5e9a82; /* deeper teal for contrast on cream */
+  --feed-thought: #a5815b;
+  --feed-line: rgba(41, 39, 31, 0.14);
+}
+
+.light .feed-item__node {
+  background: var(--background-light);
 }
 
 .light .navbar__title > a {
@@ -658,5 +754,42 @@ html.light {
   .pro-img {
     height: auto;
     width: 100%;
+  }
+
+  /* Feed — design 2b (mobile): drop date gutter, dates move under posts */
+  .feed-item__date--gutter {
+    display: none;
+  }
+
+  .feed-item__date--inline {
+    display: inline;
+  }
+
+  .feed-item__spine {
+    flex: 0 0 24px;
+  }
+
+  .feed-item__node {
+    width: 22px;
+    height: 22px;
+  }
+
+  .feed-item__node--article::before,
+  .feed-item__node--link::before {
+    width: 18px;
+    height: 18px;
+  }
+
+  .feed-item__node--thought {
+    width: 8px;
+    height: 8px;
+  }
+
+  .feed-item__content {
+    padding-left: 0.9rem;
+  }
+
+  .feed-item__sep {
+    display: inline;
   }
 }


### PR DESCRIPTION
Reimplements the feed page following the imported Claude Design project (option **2a** desktop / **2b** mobile): a vertical **timeline** with a per-type node.

## What changed
- **Timeline layout** — a vertical spine down the left with a node per post type:
  - **Article** → lines icon
  - **Link** → arrow-up-right icon
  - **Thought** → small solid dot
- **Responsive behaviour**
  - **Desktop (2a):** date sits in a left gutter, then spine + node, then content.
  - **Mobile (2b):** gutter drops away; the date moves under each post's body.
- **Kept to the project's own look** — everything uses the existing **Pacifico** (headings) / **Josefin Sans** (body) fonts and dark/light themes. I did **not** adopt the design's cream/serif/mono aesthetic.
- **Type accents** — anchored to the existing palette (link = teal `--text-link`, article = blue `--underline`) plus one warm accent for thoughts that harmonizes with the light theme. All accents have theme-aware dark/light values.
- **Per-type content** — thoughts render plain (de-italicized, the 2a trait); links keep the domain pill, external title, commentary, and `∞` permalink; articles show title + excerpt + "Read article →" and drop the old thumbnail to match 2a/2b.

## Files
- `src/components/ArticleCard.astro`
- `src/components/LinkCard.astro`
- `src/components/ThoughtBlock.astro`
- `src/styles/global.css`

## Verification
- `astro check` → 0 errors.
- Rendered locally against sample feed data and screenshotted dark desktop (2a), mobile (2b), and light desktop — all match the design's structure.