### PR TITLE
Fix missing thought node bubble in feed timeline

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -262,7 +262,8 @@ li {
 }
 
 .feed-item__node--article::before,
-.feed-item__node--link::before {
+.feed-item__node--link::before,
+.feed-item__node--thought::before {
   content: "";
   position: absolute;
   width: 20px;
@@ -292,10 +293,20 @@ li {
 }
 
 .feed-item__node--thought {
-  width: 9px;
-  height: 9px;
+  color: var(--feed-thought);
+}
+
+.feed-item__node--thought::before {
+  background: color-mix(in srgb, var(--feed-thought) 18%, transparent);
+}
+
+.feed-item__node--thought::after {
+  content: "";
+  position: relative;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
   background: var(--feed-thought);
-  margin-top: 7px;
 }
 
 /* Content column */
@@ -775,14 +786,15 @@ html.light {
   }
 
   .feed-item__node--article::before,
-  .feed-item__node--link::before {
+  .feed-item__node--link::before,
+  .feed-item__node--thought::before {
     width: 18px;
     height: 18px;
   }
 
-  .feed-item__node--thought {
-    width: 8px;
-    height: 8px;
+  .feed-item__node--thought::after {
+    width: 7px;
+    height: 7px;
   }
 
   .feed-item__content {


### PR DESCRIPTION
Follow-up to #7. Thought posts were missing their timeline node "bubble".

## Cause
Article and link nodes get a 20px tinted circle (the "bubble") via a `::before`. The thought rule instead collapsed the whole node down to a bare 9px dot with no bubble, so thoughts looked marker-less next to the other two types.

## Fix
Give the thought node the same tinted circle bubble as article/link (using the warm `--feed-thought` accent), with a small solid dot centered inside it instead of an icon. All three node types now read consistently. Applied to both the desktop rules and the mobile breakpoint.

## Verification
Rendered locally against sample feed data — the thought node now shows a warm bubble with a centered dot, matching the article (lines) and link (arrow) nodes.